### PR TITLE
Add schedule to market and id to details

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { getData } from './utils/apiCalls';
 import {
   cleanMarketsData,
   cleanDetailsData,
+  addScheduleToMarkets,
   checkForError
 } from './utils/utils';
 import { Results } from './components/Results/Results';
@@ -18,8 +19,10 @@ interface ApiMarkets {
     id: number;
     distanceFromZip: number;
     marketName: string;
+    schedule: {};
   }[];
   marketDetails: {
+    id: number;
     street: string;
     city: string;
     state: string;
@@ -49,7 +52,6 @@ export const App: React.FC = () => {
       checkForError(response);
       let data = await response.json();
       let cleanedData = cleanMarketsData(data.results, distance);
-      setMarkets(cleanedData);
       getDetails(cleanedData);
       history.push('/markets');
     } catch (error) {
@@ -62,13 +64,18 @@ export const App: React.FC = () => {
       filteredMarkets.map(currentMarket => {
         return getData(`mktDetail?id=${currentMarket.id}`)
           .then(response => checkForError(response))
-          .then(response => response.json());
+          .then(response => response.json())
+          .then(data => cleanDetailsData(data.marketdetails, currentMarket.id))
       })
     )
-      .then(arrayOfPromises => cleanDetailsData(arrayOfPromises))
-      .then(cleanData => setDetails(cleanData))
-      .catch(error => setError(error));
+    .then(data => addScheduleToMarkets(data, filteredMarkets))
+    .then(completeData => setData(completeData))
   };
+
+  const setData = (data: any) => {
+    setMarkets(data.markets)
+    setDetails(data.marketDetails)
+  }
 
   return (
     <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,13 +35,12 @@ interface ApiMarkets {
     products: string[];
     mapsLink: string;
   }[];
-  zip: string;
 }
 
 export const App: React.FC = () => {
   const [allMarkets, setMarkets] = useState<ApiMarkets['markets']>([]);
   const [marketDetails, setDetails] = useState<ApiMarkets['marketDetails']>([]);
-  const [zip, setZip] = useState<ApiMarkets['zip']>('');
+  const [zip, setZip] = useState<string>('');
   const [error, setError] = useState(0);
   const history = useHistory();
 
@@ -72,7 +71,7 @@ export const App: React.FC = () => {
     .then(completeData => setData(completeData))
   };
 
-  const setData = (data: any) => {
+  const setData = (data: ApiMarkets) => {
     setMarkets(data.markets)
     setDetails(data.marketDetails)
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ interface ApiMarkets {
     }[];
     products: string[];
     mapsLink: string;
+    name: string;
   }[];
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,8 +1,8 @@
 export const cleanMarketsData = (
-  response: { id: string; marketname: any }[], distance: number ) => {
+  response: { id: string; marketname: string }[], distance: number ) => {
   let mapped = response.map(currentMarket => {
     let name = currentMarket.marketname.split(' ');
-    let distance = name[0];
+    let distance = parseInt(name[0]);
     return {
       id: parseInt(currentMarket.id),
       distanceFromZip: Math.round(distance * 10) / 10,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,64 +1,89 @@
 export const cleanMarketsData = (
-  response: { id: string; marketname: any }[], distance: number
-) => {
+  response: { id: string; marketname: any }[], distance: number ) => {
   let mapped = response.map(currentMarket => {
     let name = currentMarket.marketname.split(' ');
     let distance = name[0];
     return {
       id: parseInt(currentMarket.id),
       distanceFromZip: Math.round(distance * 10) / 10,
-      marketName: name.slice(1).join(' ')
+      marketName: name.slice(1).join(' '),
+      schedule: {}
     };
   });
 
   return mapped.filter(currentMarket => currentMarket.distanceFromZip < distance);
 };
 
-export const cleanDetailsData = (
-  arrayOfPromises: {
-    marketdetails: {
-      GoogleLink: string;
-      Address: string;
-      Schedule: string;
-      Products: string;
-    };
-  }[]
-) => {
-  return arrayOfPromises.map(currentMarket => {
-    let addressArray = currentMarket.marketdetails.Address.split(', ');
+export const cleanDetailsData = (response: {
+    GoogleLink: string;
+    Address: string;
+    Schedule: string;
+    Products: string;
+  }, id: number) => {
 
-    let schedule = currentMarket.marketdetails.Schedule.replaceAll(
-      '<br>',
-      ''
-    ).split(';');
-    schedule.pop();
+  let addressArray = response.Address.split(', ');
+  let schedule = response.Schedule.replaceAll('<br>','').split(';');
+  schedule.pop();
 
-    let formattedSchedule = schedule.map(currentDay => {
-      let season;
-      if (currentDay.split(': ')[0].slice(0, -4).length < 24) {
-        season = 'bad format';
-      } else {
-        season = currentDay.split(': ')[0].slice(0, -4);
-      }
-
-      return {
-        dayOfWeek: currentDay.split(': ')[0].slice(-3),
-        time: currentDay.split(': ')[1],
-        season: season
-      };
-    });
+  let formattedSchedule = schedule.map(currentDay => {
+    let season;
+    if (currentDay.split(': ')[0].slice(0, -4).length < 24) {
+      season = 'bad format';
+    } else {
+      season = currentDay.split(': ')[0].slice(0, -4);
+    }
 
     return {
-      street: addressArray[0],
-      city: addressArray[addressArray.length - 3],
-      state: addressArray[addressArray.length - 2],
-      zip: addressArray[addressArray.length - 1],
-      schedule: formattedSchedule,
-      products: currentMarket.marketdetails.Products.split(';'),
-      mapsLink: currentMarket.marketdetails.GoogleLink
+      dayOfWeek: currentDay.split(': ')[0].slice(-3),
+      time: currentDay.split(': ')[1],
+      season: season
     };
   });
+
+  return {
+    id: id,
+    street: addressArray[0],
+    city: addressArray[addressArray.length - 3],
+    state: addressArray[addressArray.length - 2],
+    zip: addressArray[addressArray.length - 1],
+    schedule: formattedSchedule,
+    products: response.Products.split(';'),
+    mapsLink: response.GoogleLink
+  };
 };
+
+export const addScheduleToMarkets = (marketDetails: {
+  id: number;
+  street: string;
+  city: string;
+  state: string;
+  zip: string;
+  schedule: {
+    dayOfWeek: string;
+    time: string;
+    season: string;
+  }[];
+  products: string[];
+  mapsLink: string;
+  }[],
+  markets: {
+    id: number;
+    distanceFromZip: number;
+    marketName: string;
+    schedule: {};
+  }[]
+  ) => {
+
+  markets.forEach(market => {
+    marketDetails.forEach(currentDetails => {
+      if (market.id === currentDetails.id) {
+        market.schedule = currentDetails.schedule
+      }
+    })
+  })
+
+  return { markets: markets, marketDetails: marketDetails }
+}
 
 export const checkForError = (response: Response) => {
   if (!response.ok) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -48,7 +48,8 @@ export const cleanDetailsData = (response: {
     zip: addressArray[addressArray.length - 1],
     schedule: formattedSchedule,
     products: response.Products.split(';'),
-    mapsLink: response.GoogleLink
+    mapsLink: response.GoogleLink,
+    name: ''
   };
 };
 
@@ -65,6 +66,7 @@ export const addScheduleToMarkets = (marketDetails: {
   }[];
   products: string[];
   mapsLink: string;
+  name: string;
   }[],
   markets: {
     id: number;
@@ -78,6 +80,7 @@ export const addScheduleToMarkets = (marketDetails: {
     marketDetails.forEach(currentDetails => {
       if (market.id === currentDetails.id) {
         market.schedule = currentDetails.schedule
+        currentDetails.name = market.marketName
       }
     })
   })


### PR DESCRIPTION
### Acceptance Criteria
No user stories were harmed in the making of this PR

### Issues Resolved
#49 
Markets data did not have schedule. Now each market object contains the market's schedule. This will allow us to only have to send in markets data to list.

Details data did not have a market id. This caused us to have to send in markets and details data into details and use a bunch of string and array methods to find the match. Now we should be able to run a function in app that finds the corresponding detail object using the market.id that is clicked.

### Code Reviewers
@clairefields15 @AshleyOh-bit @Meekb 
